### PR TITLE
Updated buf_redux to buffer_redux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clippy = { version = ">=0.0, <0.1", optional = true}
 
 #Server Dependencies
 
-buf_redux = { version = "0.8", optional = true, default-features = false }
+buffer-redux = { version = "0.2", optional = true, default-features = false }
 
 httparse = { version = "1.2", optional = true }
 twoway = { version = "0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clippy = { version = ">=0.0, <0.1", optional = true}
 
 #Server Dependencies
 
-buffer-redux = { version = "0.2", optional = true, default-features = false }
+buffer-redux = { version = "1.0.1", optional = true, default-features = false }
 
 httparse = { version = "1.2", optional = true }
 twoway = { version = "0.1", optional = true }
@@ -55,7 +55,7 @@ env_logger = "0.5"
 [features]
 client = []
 default = ["client", "hyper", "iron", "mock", "nickel", "server", "tiny_http"]
-server = ["buf_redux", "httparse", "quick-error", "safemem", "twoway"]
+server = ["buffer-redux", "httparse", "quick-error", "safemem", "twoway"]
 mock = []
 nightly = []
 bench = []

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ showing how to use `multipart` on a Rocket server: [examples/rocket.rs](examples
 
 ## ⚡ Powered By ⚡
 
-### [buf_redux ![](https://img.shields.io/crates/v/buf_redux.svg)](https://crates.io/crates/buf_redux)
+### [buffer-redux ![](https://img.shields.io/crates/v/buffer-redux.svg)](https://crates.io/crates/buffer-redux)
 
 Customizable drop-in `std::io::BufReader` replacement, created to be used in this crate.
 Needed because it can read more bytes into the buffer without the buffer being empty, necessary

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -9,8 +9,8 @@
 
 use ::safemem;
 
-use super::buf_redux::BufReader;
-use super::buf_redux::policy::MinBuffered;
+use super::buffer_redux::BufReader;
+use super::buffer_redux::policy::MinBuffered;
 use super::twoway;
 
 use std::cmp;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! See the `Multipart` struct for more info.
 
-pub extern crate buf_redux;
+pub extern crate buffer_redux;
 extern crate httparse;
 extern crate twoway;
 

--- a/src/server/save.rs
+++ b/src/server/save.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //! Utilities for saving request entries to the filesystem.
 
-pub use crate::server::buf_redux::BufReader;
+pub use crate::server::buffer_redux::BufReader;
 
 pub use crate::tempfile::TempDir;
 


### PR DESCRIPTION
Updated the older unmaintained version of [buf_redux](https://github.com/abonander/buf_redux) by @abonander himself to its maintained fork [buffer-redux](https://crates.io/crates/buffer-redux).

As per the new `trailing semicolon in macro used in expression position` being phased out fix according to the issue https://github.com/rust-lang/rust/issues/79813.